### PR TITLE
[WIP] automatically add to path

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,8 +54,8 @@ Uninstall:
 .. code:: bash
 
     rm -fr ~/.pyenv
-    
-then remove these three lines from ``.bashrc``:
+
+then remove these three lines from your shell config file(``.bashrc``, ``.zshrc``, ``.profile``...):
 
 .. code:: bash
 

--- a/bin/pyenv-installer
+++ b/bin/pyenv-installer
@@ -7,6 +7,8 @@ if [ -z "$PYENV_ROOT" ]; then
   export PYENV_ROOT="${HOME}/.pyenv"
 fi
 
+SRC_WRITTEN=false
+
 colorize() {
   if [ -t 1 ]; then printf "\e[%sm%s\e[m" "$1" "$2"
   else echo -n "$2"
@@ -50,15 +52,78 @@ checkout "${GITHUB}/pyenv/pyenv-update.git"     "${PYENV_ROOT}/plugins/pyenv-upd
 checkout "${GITHUB}/pyenv/pyenv-virtualenv.git" "${PYENV_ROOT}/plugins/pyenv-virtualenv"  "master"
 checkout "${GITHUB}/pyenv/pyenv-which-ext.git"  "${PYENV_ROOT}/plugins/pyenv-which-ext"   "master"
 
-if ! command -v pyenv 1>/dev/null; then
-  { echo
-    colorize 1 "WARNING"
-    echo ": seems you still have not added 'pyenv' to the load path."
-    echo
+write_source() {
+  {
+    echo "Appending the following lines to $1:"
+    echo '  # pyenv'
+    echo '  export PATH="'"$PYENV_ROOT/bin:"'$PATH"'
+    echo '  eval "$(pyenv init --path)"'
+    echo '  eval "$(pyenv virtualenv-init -)"'
+    echo ''
   } >&2
 
-  { # Without args, `init` commands print installation help
-    "${PYENV_ROOT}/bin/pyenv" init || true
-    "${PYENV_ROOT}/bin/pyenv" virtualenv-init || true
-  } >&2
+  echo "" >>$1
+  echo '# pyenv' >>$1
+  echo 'export PATH="'"$PYENV_ROOT/bin:"'$PATH"' >>$1
+  echo 'eval "$(pyenv init --path)"' >>$1
+  echo 'eval "$(pyenv virtualenv-init -)"' >>$1
+
+  SRC_WRITTEN=true
+}
+
+add_userpath() {
+  OS="$(uname -s)"
+  CURRENT_SHELL="$(basename "$SHELL")"
+
+  if [[ "$OS" = "Darwin" ]]; then
+    if [[ "$CURRENT_SHELL" = "zsh" ]]; then
+      write_source "$HOME/.zprofile"
+    elif [[ "$CURRENT_SHELL" = "bash" ]]; then
+      write_source "$HOME/.bash_profile"
+    fi
+
+  elif [[ "$CURRENT_SHELL" = "zsh" ]]; then
+    # write to first match: zshrc/zprofile
+    if [[ -f $HOME/.zshrc ]]; then
+      write_source "$HOME/.zshrc"
+    elif [[ -f $HOME/.zprofile ]]; then
+      write_source "$HOME/.zprofile"
+    fi
+
+  elif [[ "$CURRENT_SHELL" = "bash" ]]; then
+    # bashrc
+    write_source "$HOME/.bashrc"
+
+    # write to first match: profile/bash_profile
+    if [[ -f $HOME/.profile ]]; then
+      write_source "$HOME/.profile"
+    elif [[ -f $HOME/.bash_profile ]]; then
+      write_source "$HOME/.bash_profile"
+    fi
+
+  else
+    {
+      echo "Add userpath for $CURRENT_SHELL is not currently supported"
+      echo "Please set up manually"
+    } >&2
+  fi
+}
+
+if ! command -v pyenv 1>/dev/null; then
+  add_userpath
+
+  if ${SRC_WRITTEN}; then
+    echo "Close and reopen your terminal to start using pyenv" >&2
+  else
+    { echo
+      colorize 1 "WARNING"
+      echo ": seems you still have not added 'pyenv' to the load path."
+      echo
+    } >&2
+
+    { # Without args, `init` commands print installation help
+      "${PYENV_ROOT}/bin/pyenv" init || true
+      "${PYENV_ROOT}/bin/pyenv" virtualenv-init || true
+    } >&2
+  fi
 fi

--- a/bin/pyenv-offline-installer
+++ b/bin/pyenv-offline-installer
@@ -7,6 +7,8 @@ if [ -z "$PYENV_ROOT" ]; then
   PYENV_ROOT="${HOME}/.pyenv"
 fi
 
+SRC_WRITTEN=false
+
 colorize() {
   if [ -t 1 ]; then printf "\e[%sm%s\e[m" "$1" "$2"
   else echo -n "$2"
@@ -60,16 +62,78 @@ conditional_mv "$TMP_DIR/pyenv-which-ext"  "${PYENV_ROOT}/plugins/pyenv-which-ex
 
 rm -rf $TMP_DIR
 
+write_source() {
+  {
+    echo "Appending the following lines to $1:"
+    echo '  # pyenv'
+    echo '  export PATH="'"$PYENV_ROOT/bin:"'$PATH"'
+    echo '  eval "$(pyenv init --path)"'
+    echo '  eval "$(pyenv virtualenv-init -)"'
+    echo ''
+  } >&2
+
+  echo "" >>$1
+  echo '# pyenv' >>$1
+  echo 'export PATH="'"$PYENV_ROOT/bin:"'$PATH"' >>$1
+  echo 'eval "$(pyenv init --path)"' >>$1
+  echo 'eval "$(pyenv virtualenv-init -)"' >>$1
+
+  SRC_WRITTEN=true
+}
+
+add_userpath() {
+  OS="$(uname -s)"
+  CURRENT_SHELL="$(basename "$SHELL")"
+
+  if [[ "$OS" = "Darwin" ]]; then
+    if [[ "$CURRENT_SHELL" = "zsh" ]]; then
+      write_source "$HOME/.zprofile"
+    elif [[ "$CURRENT_SHELL" = "bash" ]]; then
+      write_source "$HOME/.bash_profile"
+    fi
+
+  elif [[ "$CURRENT_SHELL" = "zsh" ]]; then
+    # write to first match: zshrc/zprofile
+    if [[ -f $HOME/.zshrc ]]; then
+      write_source "$HOME/.zshrc"
+    elif [[ -f $HOME/.zprofile ]]; then
+      write_source "$HOME/.zprofile"
+    fi
+
+  elif [[ "$CURRENT_SHELL" = "bash" ]]; then
+    # bashrc
+    write_source "$HOME/.bashrc"
+
+    # write to first match: profile/bash_profile
+    if [[ -f $HOME/.profile ]]; then
+      write_source "$HOME/.profile"
+    elif [[ -f $HOME/.bash_profile ]]; then
+      write_source "$HOME/.bash_profile"
+    fi
+
+  else
+    {
+      echo "Add userpath for $CURRENT_SHELL is not currently supported"
+      echo "Please set up manually"
+    } >&2
+  fi
+}
 
 if ! command -v pyenv 1>/dev/null; then
-  { echo
-    colorize 1 "WARNING"
-    echo ": seems you still have not added 'pyenv' to the load path."
-    echo
-  } >&2
+  add_userpath
 
-  { # Without args, `init` commands print installation help
-    "${PYENV_ROOT}/bin/pyenv" init || true
-    "${PYENV_ROOT}/bin/pyenv" virtualenv-init || true
-  } >&2
+  if ${SRC_WRITTEN}; then
+    echo "Close and reopen your terminal to start using pyenv" >&2
+  else
+    { echo
+      colorize 1 "WARNING"
+      echo ": seems you still have not added 'pyenv' to the load path."
+      echo
+    } >&2
+
+    { # Without args, `init` commands print installation help
+      "${PYENV_ROOT}/bin/pyenv" init || true
+      "${PYENV_ROOT}/bin/pyenv" virtualenv-init || true
+    } >&2
+  fi
 fi


### PR DESCRIPTION
Fix: https://github.com/pyenv/pyenv-installer/issues/112

For users using the installation script, it is natural that the environment variables will be automatically modified

Outline
+ Modify user's profile based on current shell & system(bash & zsh, currently)

Discussion:
+ Should we add an environment variable, so that users can choose not to modify their shell config profiles?

**References**
+ https://github.com/nvm-sh/nvm#install--update-script
+ https://github.com/ofek/userpath
+ https://github.com/ofek/userpath/issues/3